### PR TITLE
recursive dirs

### DIFF
--- a/server/src/lib.ts
+++ b/server/src/lib.ts
@@ -3,6 +3,6 @@ import fs from "fs";
 export function datadir(): string {
     let base = (process.env.APPDATA || (process.platform == 'darwin' ? process.env.HOME + '/Library/Preferences' : process.env.HOME + "/.config")) + "/adrift-server"
     if (!fs.existsSync(base))
-        fs.mkdirSync(base);
+        fs.mkdirSync(base, { recursive: true });
     return base;
 }


### PR DESCRIPTION
![image](https://github.com/MercuryWorkshop/adrift/assets/59001842/14d9a50f-a55d-43ad-907d-123d624a32de)

the server currently doesn't recursively make the config directory, causing it to crash on environments without `.config` or whatever other data dir there is.